### PR TITLE
Disable npm lifecycle scripts for security

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,5 @@
 tasks:
-  - init: npm install
+  - init: npm install --ignore-scripts
 ports:
   - port: 3000
     onOpen: open-preview


### PR DESCRIPTION
Add `--ignore-scripts` flag to npm install to prevent execution of potentially malicious scripts during package installation.

Related to [PDE-128](https://linear.app/ona-team/issue/PDE-128/parent-issue-disabling-npm-lifecycle-scripts)